### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Basic:
 ```yml
 steps:
   - uses: actions/checkout@v1
-  - uses: rahul-deepsource/pyaction@v1.4.0
+  - uses: rahul-deepsource/pyaction@1.4.0
 ```
 
 Options:
@@ -35,7 +35,7 @@ Options:
 ```yml
 steps:
   - uses: actions/checkout@v1
-  - uses: rahul-deepsource/pyaction@v1.4.0
+  - uses: rahul-deepsource/pyaction@1.4.0
     with:
       python-root-list: "src/ tests/"
       use-pycodestyle: false


### PR DESCRIPTION
The 'v' was dropped from the release tag starting with `pyaction=1.4`. Therefore it should be removed from the examples.

Addresses the part of #2 about the version specifier not working.